### PR TITLE
Mop 121 - update transaction search

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ group :development do
   gem 'rspec'
   gem 'webmock'
   gem 'bundler'
+  gem 'rexml'
 end
 
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,6 +25,7 @@ GEM
     minitest (5.14.4)
     public_suffix (4.0.6)
     rake (12.3.3)
+    rexml (3.4.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -53,6 +54,7 @@ PLATFORMS
 DEPENDENCIES
   bundler
   rake (~> 12.3)
+  rexml
   rspec
   webmock
   wf_transaction_detail!

--- a/lib/http_client.rb
+++ b/lib/http_client.rb
@@ -19,6 +19,8 @@ module WFTransactionDetail
     MAX_RETRIES = 'WF_MAX_RETRIES'
     DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
     DATE_FORMAT = '%Y-%m-%d'
+    INTRADAY = 'intraday'
+    PREVIOUS_DAY_COMPOSITE = 'previous_day_composite'
 
     def initialize()
       uri = ENV[API_BASE_URL]
@@ -108,7 +110,7 @@ module WFTransactionDetail
     # end_datetime:           (required) DateTime value
     # Wells Fargo docs for transactions/search - https://developer.wellsfargo.com/documentation/api-references/account-transactions/v3/transaction-detail-api-ref-v3#search-for-transactions
     def transaction_search(account_collection:, debit_credit_indicator:"ALL", transaction_mode: nil, start_datetime: nil, end_datetime: nil, next_cursor: nil, transaction_types: [])
-      raise ArgumentError, 'transaction_mode required. accepted values are intraday or previous_day_composite' if !transaction_mode || !['intraday', 'previous_day_composite'].include?(transaction_mode)
+      raise ArgumentError, "transaction_mode required. accepted values are #{INTRADAY} or #{PREVIOUS_DAY_COMPOSITE}" if !transaction_mode || ![INTRADAY, PREVIOUS_DAY_COMPOSITE].include?(transaction_mode)
       raise ArgumentError, 'start_datetime needs to be a DateTime value' if !start_datetime || !start_datetime.is_a?(DateTime)
       raise ArgumentError, 'end_datetime needs to be a DateTime value' if !end_datetime || !end_datetime.is_a?(DateTime)
       raise TypeError, 'transaction_search expects an AccountCollection' unless account_collection.kind_of?(WFTransactionDetail::AccountCollection)
@@ -129,14 +131,14 @@ module WFTransactionDetail
       }
       start_value = nil
       end_value = nil
-      if transaction_mode == 'intraday'
+      if transaction_mode == INTRADAY
         start_value = start_datetime.strftime(DATETIME_FORMAT)
         end_value = end_datetime.strftime(DATETIME_FORMAT)
         payload['datetime_range'] = {
           "start_transaction_datetime" => start_value,
           "end_transaction_datetime" => end_value
         }
-      elsif transaction_mode == 'previous_day_composite'
+      elsif transaction_mode == PREVIOUS_DAY_COMPOSITE
         start_value = start_datetime.strftime(DATE_FORMAT)
         end_value = end_datetime.strftime(DATE_FORMAT)
         payload['date_range'] = {

--- a/spec/http_client_spec.rb
+++ b/spec/http_client_spec.rb
@@ -42,7 +42,7 @@ describe WFTransactionDetail::Client do
       end_datetime = DateTime.new(2019,9,11,23,59,59)
       transaction_detail = client.transaction_search(
         account_collection: accounts,
-        transaction_mode: 'intraday',
+        transaction_mode: WFTransactionDetail::Client::INTRADAY,
         start_datetime: start_datetime,
         end_datetime: end_datetime
       )
@@ -72,7 +72,7 @@ describe WFTransactionDetail::Client do
       end_datetime = DateTime.new(2019,9,11,23,59,59)
       expect{ client.transaction_search(
         account_collection: accounts,
-        transaction_mode: 'intraday',
+        transaction_mode: WFTransactionDetail::Client::INTRADAY,
         start_datetime: start_datetime,
         end_datetime: end_datetime
       ) }.to raise_error(WFTransactionDetail::HTTPError, "Unauthorized")
@@ -84,7 +84,7 @@ describe WFTransactionDetail::Client do
       end_datetime = DateTime.new(2019,9,18,23,59,59)
       expect{ client.transaction_search(
         account_collection: accounts,
-        transaction_mode: 'intraday',
+        transaction_mode: WFTransactionDetail::Client::INTRADAY,
         start_datetime: start_datetime,
         end_datetime: end_datetime
       ) }.to raise_error(WFTransactionDetail::HTTPError, /\{"errors":\[\{"error_code":"1018-011","description"/)
@@ -96,7 +96,7 @@ describe WFTransactionDetail::Client do
       end_datetime = DateTime.new(2019,9,11,23,59,59)
       expect{ client.transaction_search(
         account_collection: accounts,
-        transaction_mode: 'intraday',
+        transaction_mode: WFTransactionDetail::Client::INTRADAY,
         start_datetime: start_datetime,
         end_datetime: end_datetime,
         next_cursor:"123415t"
@@ -109,7 +109,7 @@ describe WFTransactionDetail::Client do
       end_datetime = DateTime.new(2019,9,11,23,59,59)
       collection = client.transaction_search(
         account_collection: accounts,
-        transaction_mode: 'intraday',
+        transaction_mode: WFTransactionDetail::Client::INTRADAY,
         start_datetime: start_datetime,
         end_datetime: end_datetime
       )
@@ -122,7 +122,7 @@ describe WFTransactionDetail::Client do
       end_datetime = DateTime.new(2019,9,11,0,0,01)
       collection = client.transaction_search(
         account_collection: accounts,
-        transaction_mode: 'intraday',
+        transaction_mode: WFTransactionDetail::Client::INTRADAY,
         start_datetime: start_datetime,
         end_datetime: end_datetime
       )
@@ -134,7 +134,7 @@ describe WFTransactionDetail::Client do
       start_and_end_datetime = DateTime.new(2019,9,11,0,0,0)
       collection = client.transaction_search(
         account_collection: accounts,
-        transaction_mode: 'previous_day_composite',
+        transaction_mode: WFTransactionDetail::Client::PREVIOUS_DAY_COMPOSITE,
         start_datetime: start_and_end_datetime,
         end_datetime: start_and_end_datetime,
         transaction_types: ['MISCELLANEOUS', 'ACH']
@@ -157,7 +157,7 @@ describe WFTransactionDetail::Client do
       start_and_end_datetime = '2019-09-11'
       expect{ client.transaction_search(
         account_collection: accounts,
-        transaction_mode: 'previous_day_composite',
+        transaction_mode: WFTransactionDetail::Client::PREVIOUS_DAY_COMPOSITE,
         start_datetime: start_and_end_datetime,
         end_datetime: start_and_end_datetime
       ) }.to raise_error(ArgumentError)
@@ -168,7 +168,7 @@ describe WFTransactionDetail::Client do
       start_and_end_datetime = DateTime.new(2019,9,11,0,0,0)
       expect{ client.transaction_search(
         account_collection: accounts,
-        transaction_mode: 'previous_day_composite',
+        transaction_mode: WFTransactionDetail::Client::PREVIOUS_DAY_COMPOSITE,
         start_datetime: start_and_end_datetime,
         end_datetime: start_and_end_datetime,
         transaction_types: ['BOGUSSSS']

--- a/spec/http_client_spec.rb
+++ b/spec/http_client_spec.rb
@@ -40,10 +40,13 @@ describe WFTransactionDetail::Client do
       accounts = WFTransactionDetail::AccountCollection.new("111111111", ["2222222222","3333333333"])
       start_datetime = DateTime.new(2019,9,11,0,0,0)
       end_datetime = DateTime.new(2019,9,11,23,59,59)
+      datetime_range = {
+        'start_datetime' => start_datetime,
+        'end_datetime' => end_datetime
+      }
       transaction_detail = client.transaction_search(
-        accounts,
-        start_datetime,
-        end_datetime,
+        account_collection: accounts,
+        datetime_range: datetime_range
       )
 
       expect(transaction_detail.transactions(2222222222).length).to eq(3)
@@ -69,10 +72,13 @@ describe WFTransactionDetail::Client do
       accounts = WFTransactionDetail::AccountCollection.new("111111111", ["2222222222","3333333333"])
       start_datetime = DateTime.new(2019,9,11,0,0,0)
       end_datetime = DateTime.new(2019,9,11,23,59,59)
+      datetime_range = {
+        'start_datetime' => start_datetime,
+        'end_datetime' => end_datetime
+      }
       expect{ client.transaction_search(
-        accounts,
-        start_datetime,
-        end_datetime,
+        account_collection: accounts,
+        datetime_range: datetime_range
       ) }.to raise_error(WFTransactionDetail::HTTPError, "Unauthorized")
     end
 
@@ -80,10 +86,13 @@ describe WFTransactionDetail::Client do
       accounts = WFTransactionDetail::AccountCollection.new("111111111", ["2222222222","3333333333"])
       start_datetime = DateTime.new(2019,9,11,0,0,0)
       end_datetime = DateTime.new(2019,9,18,23,59,59)
+      datetime_range = {
+        'start_datetime' => start_datetime,
+        'end_datetime' => end_datetime
+      }
       expect{ client.transaction_search(
-        accounts,
-        start_datetime,
-        end_datetime,
+        account_collection: accounts,
+        datetime_range: datetime_range
       ) }.to raise_error(WFTransactionDetail::HTTPError, /\{"errors":\[\{"error_code":"1018-011","description"/)
     end
 
@@ -91,10 +100,13 @@ describe WFTransactionDetail::Client do
       accounts = WFTransactionDetail::AccountCollection.new("111111111", ["2222222222","3333333333"])
       start_datetime = DateTime.new(2019,9,11,0,0,0)
       end_datetime = DateTime.new(2019,9,11,23,59,59)
+      datetime_range = {
+        'start_datetime' => start_datetime,
+        'end_datetime' => end_datetime
+      }
       expect{ client.transaction_search(
-        accounts,
-        start_datetime,
-        end_datetime,
+        account_collection: accounts,
+        datetime_range: datetime_range,
         next_cursor:"123415t"
       ) }.to raise_error(ArgumentError)
     end
@@ -103,10 +115,13 @@ describe WFTransactionDetail::Client do
       accounts = WFTransactionDetail::AccountCollection.new("111111111", ["2222222222","3333333333"])
       start_datetime = DateTime.new(2019,9,11,0,0,0)
       end_datetime = DateTime.new(2019,9,11,23,59,59)
+      datetime_range = {
+        'start_datetime' => start_datetime,
+        'end_datetime' => end_datetime
+      }
       collection = client.transaction_search(
-        accounts,
-        start_datetime,
-        end_datetime,
+        account_collection: accounts,
+        datetime_range: datetime_range
       )
       expect(collection.next_cursor).to be(nil)
     end
@@ -115,13 +130,100 @@ describe WFTransactionDetail::Client do
       accounts = WFTransactionDetail::AccountCollection.new("111111111", ["2222222222","3333333333"])
       start_datetime = DateTime.new(2019,9,11,0,0,0)
       end_datetime = DateTime.new(2019,9,11,0,0,01)
+      datetime_range = {
+        'start_datetime' => start_datetime,
+        'end_datetime' => end_datetime
+      }
       collection = client.transaction_search(
-        accounts,
-        start_datetime,
-        end_datetime,
+        account_collection: accounts,
+        datetime_range: datetime_range
       )
       expect(collection.next_cursor).to be(nil)
     end
+
+    it 'sets transaction_type_list in the payload if transaction_types are provided' do
+      accounts = WFTransactionDetail::AccountCollection.new("111111111", ["2222222222","3333333333"])
+      date = Date.new(2019,9,11)
+      date_range = {
+        'start_date' => date,
+        'end_date' => date
+      }
+      collection = client.transaction_search(
+        account_collection: accounts,
+        date_range: date_range,
+        transaction_types: ['MISCELLANEOUS', 'ACH']
+      )
+      expect(collection.transactions(2222222222).length).to eq(3)
+    end
+
+    it 'returns an argument error if datetime_range and date_range are not provided' do
+      accounts = WFTransactionDetail::AccountCollection.new("111111111", ["2222222222","3333333333"])
+      expect{ client.transaction_search(
+        account_collection: accounts
+      ) }.to raise_error(ArgumentError)
+    end
+
+    it 'returns an argument error if both datetime_range and date_range are provided' do
+      accounts = WFTransactionDetail::AccountCollection.new("111111111", ["2222222222","3333333333"])
+      date_range = {
+        'start_date' => Date.new(2019,9,11),
+        'end_date' => Date.new(2019,9,11)
+      }
+      datetime_range = {
+        'start_datetime' => DateTime.new(2019,9,11,0,0,0),
+        'end_datetime' => DateTime.new(2019,9,11,0,0,0)
+      }
+      expect{ client.transaction_search(
+        account_collection: accounts,
+        date_range: date_range,
+        datetime_range: datetime_range
+      ) }.to raise_error(ArgumentError)
+    end
+
+    it 'returns an argument error if a date_range is provided but start_date is not provided' do
+      accounts = WFTransactionDetail::AccountCollection.new("111111111", ["2222222222","3333333333"])
+      date_range = {
+        'end_date' => Date.new(2019,9,11)
+      }
+      expect{ client.transaction_search(
+        account_collection: accounts,
+        date_range: date_range
+      ) }.to raise_error(ArgumentError)
+    end
+
+    it 'returns an argument error if a date_range is provided but end_date is not provided' do
+      accounts = WFTransactionDetail::AccountCollection.new("111111111", ["2222222222","3333333333"])
+      date_range = {
+        'start_date' => Date.new(2019,9,11)
+      }
+      expect{ client.transaction_search(
+        account_collection: accounts,
+        date_range: date_range
+      ) }.to raise_error(ArgumentError)
+    end
+
+    it 'returns an argument error if a datetime_range is provided but end_datetime is not provided' do
+      accounts = WFTransactionDetail::AccountCollection.new("111111111", ["2222222222","3333333333"])
+      date_range = {
+        'start_datetime' => DateTime.new(2019,9,11,0,0,0)
+      }
+      expect{ client.transaction_search(
+        account_collection: accounts,
+        date_range: date_range
+      ) }.to raise_error(ArgumentError)
+    end
+
+    it 'returns an argument error if a datetime_range is provided but start_datetime is not provided' do
+      accounts = WFTransactionDetail::AccountCollection.new("111111111", ["2222222222","3333333333"])
+      date_range = {
+        'end_datetime' => DateTime.new(2019,9,11,0,0,0)
+      }
+      expect{ client.transaction_search(
+        account_collection: accounts,
+        date_range: date_range
+      ) }.to raise_error(ArgumentError)
+    end
+
   end
 end
 

--- a/spec/http_client_spec.rb
+++ b/spec/http_client_spec.rb
@@ -40,13 +40,11 @@ describe WFTransactionDetail::Client do
       accounts = WFTransactionDetail::AccountCollection.new("111111111", ["2222222222","3333333333"])
       start_datetime = DateTime.new(2019,9,11,0,0,0)
       end_datetime = DateTime.new(2019,9,11,23,59,59)
-      datetime_range = {
-        'start_datetime' => start_datetime,
-        'end_datetime' => end_datetime
-      }
       transaction_detail = client.transaction_search(
         account_collection: accounts,
-        datetime_range: datetime_range
+        transaction_mode: 'intraday',
+        start_datetime: start_datetime,
+        end_datetime: end_datetime
       )
 
       expect(transaction_detail.transactions(2222222222).length).to eq(3)
@@ -72,13 +70,11 @@ describe WFTransactionDetail::Client do
       accounts = WFTransactionDetail::AccountCollection.new("111111111", ["2222222222","3333333333"])
       start_datetime = DateTime.new(2019,9,11,0,0,0)
       end_datetime = DateTime.new(2019,9,11,23,59,59)
-      datetime_range = {
-        'start_datetime' => start_datetime,
-        'end_datetime' => end_datetime
-      }
       expect{ client.transaction_search(
         account_collection: accounts,
-        datetime_range: datetime_range
+        transaction_mode: 'intraday',
+        start_datetime: start_datetime,
+        end_datetime: end_datetime
       ) }.to raise_error(WFTransactionDetail::HTTPError, "Unauthorized")
     end
 
@@ -86,13 +82,11 @@ describe WFTransactionDetail::Client do
       accounts = WFTransactionDetail::AccountCollection.new("111111111", ["2222222222","3333333333"])
       start_datetime = DateTime.new(2019,9,11,0,0,0)
       end_datetime = DateTime.new(2019,9,18,23,59,59)
-      datetime_range = {
-        'start_datetime' => start_datetime,
-        'end_datetime' => end_datetime
-      }
       expect{ client.transaction_search(
         account_collection: accounts,
-        datetime_range: datetime_range
+        transaction_mode: 'intraday',
+        start_datetime: start_datetime,
+        end_datetime: end_datetime
       ) }.to raise_error(WFTransactionDetail::HTTPError, /\{"errors":\[\{"error_code":"1018-011","description"/)
     end
 
@@ -100,13 +94,11 @@ describe WFTransactionDetail::Client do
       accounts = WFTransactionDetail::AccountCollection.new("111111111", ["2222222222","3333333333"])
       start_datetime = DateTime.new(2019,9,11,0,0,0)
       end_datetime = DateTime.new(2019,9,11,23,59,59)
-      datetime_range = {
-        'start_datetime' => start_datetime,
-        'end_datetime' => end_datetime
-      }
       expect{ client.transaction_search(
         account_collection: accounts,
-        datetime_range: datetime_range,
+        transaction_mode: 'intraday',
+        start_datetime: start_datetime,
+        end_datetime: end_datetime,
         next_cursor:"123415t"
       ) }.to raise_error(ArgumentError)
     end
@@ -115,13 +107,11 @@ describe WFTransactionDetail::Client do
       accounts = WFTransactionDetail::AccountCollection.new("111111111", ["2222222222","3333333333"])
       start_datetime = DateTime.new(2019,9,11,0,0,0)
       end_datetime = DateTime.new(2019,9,11,23,59,59)
-      datetime_range = {
-        'start_datetime' => start_datetime,
-        'end_datetime' => end_datetime
-      }
       collection = client.transaction_search(
         account_collection: accounts,
-        datetime_range: datetime_range
+        transaction_mode: 'intraday',
+        start_datetime: start_datetime,
+        end_datetime: end_datetime
       )
       expect(collection.next_cursor).to be(nil)
     end
@@ -130,98 +120,59 @@ describe WFTransactionDetail::Client do
       accounts = WFTransactionDetail::AccountCollection.new("111111111", ["2222222222","3333333333"])
       start_datetime = DateTime.new(2019,9,11,0,0,0)
       end_datetime = DateTime.new(2019,9,11,0,0,01)
-      datetime_range = {
-        'start_datetime' => start_datetime,
-        'end_datetime' => end_datetime
-      }
       collection = client.transaction_search(
         account_collection: accounts,
-        datetime_range: datetime_range
+        transaction_mode: 'intraday',
+        start_datetime: start_datetime,
+        end_datetime: end_datetime
       )
       expect(collection.next_cursor).to be(nil)
     end
 
     it 'sets transaction_type_list in the payload if transaction_types are provided' do
       accounts = WFTransactionDetail::AccountCollection.new("111111111", ["2222222222","3333333333"])
-      date = Date.new(2019,9,11)
-      date_range = {
-        'start_date' => date,
-        'end_date' => date
-      }
+      start_and_end_datetime = DateTime.new(2019,9,11,0,0,0)
       collection = client.transaction_search(
         account_collection: accounts,
-        date_range: date_range,
+        transaction_mode: 'previous_day_composite',
+        start_datetime: start_and_end_datetime,
+        end_datetime: start_and_end_datetime,
         transaction_types: ['MISCELLANEOUS', 'ACH']
       )
       expect(collection.transactions(2222222222).length).to eq(3)
     end
 
-    it 'returns an argument error if datetime_range and date_range are not provided' do
+    it 'returns an argument error if transaction_mode is not provided' do
       accounts = WFTransactionDetail::AccountCollection.new("111111111", ["2222222222","3333333333"])
+      start_and_end_datetime = DateTime.new(2019,9,11,0,0,0)
       expect{ client.transaction_search(
-        account_collection: accounts
+        account_collection: accounts,
+        start_datetime: start_and_end_datetime,
+        end_datetime: start_and_end_datetime
       ) }.to raise_error(ArgumentError)
     end
 
-    it 'returns an argument error if both datetime_range and date_range are provided' do
+    it 'returns an argument error if start_datetime is not a DateTime' do
       accounts = WFTransactionDetail::AccountCollection.new("111111111", ["2222222222","3333333333"])
-      date_range = {
-        'start_date' => Date.new(2019,9,11),
-        'end_date' => Date.new(2019,9,11)
-      }
-      datetime_range = {
-        'start_datetime' => DateTime.new(2019,9,11,0,0,0),
-        'end_datetime' => DateTime.new(2019,9,11,0,0,0)
-      }
+      start_and_end_datetime = '2019-09-11'
       expect{ client.transaction_search(
         account_collection: accounts,
-        date_range: date_range,
-        datetime_range: datetime_range
+        transaction_mode: 'previous_day_composite',
+        start_datetime: start_and_end_datetime,
+        end_datetime: start_and_end_datetime
       ) }.to raise_error(ArgumentError)
     end
 
-    it 'returns an argument error if a date_range is provided but start_date is not provided' do
+    it 'returns an http error when an invalid transaction type is used' do
       accounts = WFTransactionDetail::AccountCollection.new("111111111", ["2222222222","3333333333"])
-      date_range = {
-        'end_date' => Date.new(2019,9,11)
-      }
+      start_and_end_datetime = DateTime.new(2019,9,11,0,0,0)
       expect{ client.transaction_search(
         account_collection: accounts,
-        date_range: date_range
-      ) }.to raise_error(ArgumentError)
-    end
-
-    it 'returns an argument error if a date_range is provided but end_date is not provided' do
-      accounts = WFTransactionDetail::AccountCollection.new("111111111", ["2222222222","3333333333"])
-      date_range = {
-        'start_date' => Date.new(2019,9,11)
-      }
-      expect{ client.transaction_search(
-        account_collection: accounts,
-        date_range: date_range
-      ) }.to raise_error(ArgumentError)
-    end
-
-    it 'returns an argument error if a datetime_range is provided but end_datetime is not provided' do
-      accounts = WFTransactionDetail::AccountCollection.new("111111111", ["2222222222","3333333333"])
-      date_range = {
-        'start_datetime' => DateTime.new(2019,9,11,0,0,0)
-      }
-      expect{ client.transaction_search(
-        account_collection: accounts,
-        date_range: date_range
-      ) }.to raise_error(ArgumentError)
-    end
-
-    it 'returns an argument error if a datetime_range is provided but start_datetime is not provided' do
-      accounts = WFTransactionDetail::AccountCollection.new("111111111", ["2222222222","3333333333"])
-      date_range = {
-        'end_datetime' => DateTime.new(2019,9,11,0,0,0)
-      }
-      expect{ client.transaction_search(
-        account_collection: accounts,
-        date_range: date_range
-      ) }.to raise_error(ArgumentError)
+        transaction_mode: 'previous_day_composite',
+        start_datetime: start_and_end_datetime,
+        end_datetime: start_and_end_datetime,
+        transaction_types: ['BOGUSSSS']
+      ) }.to raise_error(WFTransactionDetail::HTTPError)
     end
 
   end

--- a/spec/mock_responses/transaction_detail_request_bad_transaction_type.json
+++ b/spec/mock_responses/transaction_detail_request_bad_transaction_type.json
@@ -1,0 +1,23 @@
+{
+  "debit_credit_indicator": "ALL",
+  "limit": 100,
+  "date_range": {
+    "start_posting_date": "2019-09-11",
+    "end_posting_date": "2019-09-11"
+  },
+  "transaction_type_list": [
+        {
+            "transaction_type": "BOGUSSSS"
+        }
+  ],
+  "accounts": [
+    {
+      "bank_id": "111111111",
+      "account_number": "2222222222"
+    },
+    {
+      "bank_id": "111111111",
+      "account_number": "3333333333"
+    }
+  ]
+}

--- a/spec/mock_responses/transaction_detail_request_error.json
+++ b/spec/mock_responses/transaction_detail_request_error.json
@@ -1,10 +1,10 @@
 {
+  "debit_credit_indicator": "ALL",
+  "limit": 100,
   "datetime_range": {
     "start_transaction_datetime": "2019-09-11T00:00:00Z",
     "end_transaction_datetime": "2019-09-18T23:59:59Z"
   },
-  "debit_credit_indicator": "ALL",
-  "limit": 100,
   "accounts": [
     {
       "bank_id": "111111111",

--- a/spec/mock_responses/transaction_detail_request_valid.json
+++ b/spec/mock_responses/transaction_detail_request_valid.json
@@ -1,10 +1,10 @@
 {
+  "debit_credit_indicator": "ALL",
+  "limit": 100,
   "datetime_range": {
     "start_transaction_datetime": "2019-09-11T00:00:00Z",
     "end_transaction_datetime": "2019-09-11T23:59:59Z"
   },
-  "debit_credit_indicator": "ALL",
-  "limit": 100,
   "accounts": [
     {
       "bank_id": "111111111",

--- a/spec/mock_responses/transaction_detail_request_valid_with_no_transactions.json
+++ b/spec/mock_responses/transaction_detail_request_valid_with_no_transactions.json
@@ -1,10 +1,10 @@
 {
+  "debit_credit_indicator": "ALL",
+  "limit": 100,
   "datetime_range": {
     "start_transaction_datetime": "2019-09-11T00:00:00Z",
     "end_transaction_datetime": "2019-09-11T00:00:01Z"
   },
-  "debit_credit_indicator": "ALL",
-  "limit": 100,
   "accounts": [
     {
       "bank_id": "111111111",

--- a/spec/mock_responses/transaction_detail_request_with_next_cursor_valid.json
+++ b/spec/mock_responses/transaction_detail_request_with_next_cursor_valid.json
@@ -1,10 +1,10 @@
 {
+  "debit_credit_indicator": "ALL",
+  "limit": 100,
   "datetime_range": {
     "start_transaction_datetime": "2019-09-11T00:00:00Z",
     "end_transaction_datetime": "2019-09-11T23:59:59Z"
   },
-  "debit_credit_indicator": "ALL",
-  "limit": 100,
   "accounts": [
     {
       "bank_id": "111111111",

--- a/spec/mock_responses/transaction_detail_request_with_transaction_types.json
+++ b/spec/mock_responses/transaction_detail_request_with_transaction_types.json
@@ -1,0 +1,26 @@
+{
+  "debit_credit_indicator": "ALL",
+  "limit": 100,
+  "date_range": {
+    "start_posting_date": "2019-09-11",
+    "end_posting_date": "2019-09-11"
+  },
+  "transaction_type_list": [
+        {
+            "transaction_type": "MISCELLANEOUS"
+        },
+        {
+            "transaction_type": "ACH"
+        }
+  ],
+  "accounts": [
+    {
+      "bank_id": "111111111",
+      "account_number": "2222222222"
+    },
+    {
+      "bank_id": "111111111",
+      "account_number": "3333333333"
+    }
+  ]
+}

--- a/spec/mock_responses/transaction_detail_response_bad_transaction_type.json
+++ b/spec/mock_responses/transaction_detail_response_bad_transaction_type.json
@@ -1,0 +1,11 @@
+{
+  "errors": [
+    {
+      "error_code":"400-012",
+      "description":"\u0027transaction_type\u0027 contains an invalid value.",
+      "field_name":"transaction_type_list.0.transaction_type",
+      "field_value":"BOGUSSSS",
+      "api_specification_url":"https://developer.wellsfargo.com"
+    }
+  ]
+}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -97,6 +97,20 @@ RSpec.configure do |config|
             to_return(status: 200, body: get_json_mock("transaction_detail_response_valid.json"), headers: {})
     stub_request(:post, "https://api-sandbox.wellsfargo.com/treasury/transaction-reporting/v3/transactions/search").
         with(
+            body: get_json_mock("transaction_detail_request_with_transaction_types.json"),
+            headers: {
+                'Accept' => '*/*',
+                'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                'Authorization' => 'Bearer bogustogus',
+                'Content-Type' => 'application/json',
+                'Client-Request-Id' => 'bogus-request-id',
+                'Gateway-Entity-Id' => 'bogus-entity-id',
+                'Host' => 'api-sandbox.wellsfargo.com',
+                'User-Agent' => 'Ruby'
+            }).
+            to_return(status: 200, body: get_json_mock("transaction_detail_response_valid.json"), headers: {})
+    stub_request(:post, "https://api-sandbox.wellsfargo.com/treasury/transaction-reporting/v3/transactions/search").
+        with(
             body: get_json_mock("transaction_detail_request_error.json"),
             headers: {
                 'Accept' => '*/*',

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -134,6 +134,20 @@ RSpec.configure do |config|
                 'User-Agent' => 'Ruby'
             }).
         to_return(status: 401, body: "Unauthorized", headers: {})
+    stub_request(:post, "https://api-sandbox.wellsfargo.com/treasury/transaction-reporting/v3/transactions/search").
+        with(
+            body: get_json_mock("transaction_detail_request_bad_transaction_type.json"),
+            headers: {
+                'Accept' => '*/*',
+                'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                'Authorization' => 'Bearer bogustogus',
+                'Content-Type' => 'application/json',
+                'Client-Request-Id' => 'bogus-request-id',
+                'Gateway-Entity-Id' => 'bogus-entity-id',
+                'Host' => 'api-sandbox.wellsfargo.com',
+                'User-Agent' => 'Ruby'
+            }).
+            to_return(status: 400, body: get_json_mock("transaction_detail_response_bad_transaction_type.json"), headers: {})
   end
 
   # This option will default to `:apply_to_host_groups` in RSpec 4 (and will


### PR DESCRIPTION
- added an option to pass in date ranges. now we can either pass in a date_range object or a datetime_range object. 
- added an option to pass in transaction types